### PR TITLE
Index.php: add pacman to local installation notice

### DIFF
--- a/index.php
+++ b/index.php
@@ -198,6 +198,7 @@ find backups/ \
         <a href="https://github.com/benliddicott">benliddicott</a>
         &#8226; <a href="https://gitpod.io">Gitpod</a>
         &#8226; <a href="https://github.com/aniravi24">aniravi24</a>
+        &#8226; <a href="https://opensource.mercedes-benz.com/">Mercedes-Benz</a> <!-- mercedes-benz -->
 
         &#8226; <a href="https://github.com/per1234">per1234</a>
         &#8226; <a href="https://www.bashsupport.com/pro/">BashSupport Pro</a> <!-- jansorg -->

--- a/index.php
+++ b/index.php
@@ -129,7 +129,7 @@ find backups/ \
       </div>
 
       <div class="contentpart">
-        You can <code>cabal</code>, <code>apt</code>, <code>dnf</code>, <code>pkg</code> or <code>brew&nbsp;install</code> it locally right&nbsp;now.
+        You can <code>cabal</code>, <code>apt</code>, <code>dnf</code>, <code>pkg</code>, <code>pacman</code> or <code>brew&nbsp;install</code> it locally right&nbsp;now.
       </div>
 
       <div class="contentpart">

--- a/index.php
+++ b/index.php
@@ -213,6 +213,7 @@ find backups/ \
         &#8226; <a href="https://github.com/pystardust/ani-cli">ani-cli</a>
         &#8226; <a href="https://codiga.io/">codiga.io</a>
         &#8226; <a href="https://SnapShooter.com">SnapShooter Backups</a>
+        &#8226; <a href="https://github.com/steve-chavez">steve-chavez</a>
       </div>
     </div>
     <p style="display: none"><a href="/wiki/">Wiki Sitemap</a></p>

--- a/index.php
+++ b/index.php
@@ -195,24 +195,17 @@ find backups/ \
       <div class="contentpart">
         A special thanks to the <a href="https://github.com/sponsors/koalaman">GitHub Sponsors</a>:
 
-        <a href="https://github.com/benliddicott">benliddicott</a>
-        &#8226; <a href="https://gitpod.io">Gitpod</a>
-        &#8226; <a href="https://github.com/aniravi24">aniravi24</a>
+        <a href="https://gitpod.io">Gitpod</a>
         &#8226; <a href="https://opensource.mercedes-benz.com/">Mercedes-Benz</a> <!-- mercedes-benz -->
+        &#8226; <a href="https://www.bashsupport.com/pro/">BashSupport Pro</a> <!-- jansorg -->
 
         &#8226; <a href="https://github.com/per1234">per1234</a>
-        &#8226; <a href="https://www.bashsupport.com/pro/">BashSupport Pro</a> <!-- jansorg -->
-        &#8226; <a href="https://github.com/per1234">per1234</a>
         &#8226; <a href="https://github.com/WhitewaterFoundry">WhitewaterFoundry</a>
-        &#8226; <a href="https://github.com/reap2sow1">reap2sow1</a>
+        &#8226; <a href="https://github.com/cavcrosby">cavcrosby</a>
         &#8226; <a href="https://github.com/dcminter">dcminter</a>
         &#8226; <a href="https://github.com/photostructure">photostructure</a>
         &#8226; <a href="https://cronitor.io">Cronitor</a>
-        &#8226; <a href="https://github.com/devholic">devholic</a>
-        &#8226; <a href="https://github.com/qmacro">qmacro</a>
-        &#8226; <a href="https://github.com/pystardust/ani-cli">ani-cli</a>
-        &#8226; <a href="https://codiga.io/">codiga.io</a>
-        &#8226; <a href="https://SnapShooter.com">SnapShooter Backups</a>
+        &#8226; <a href="https://github.com/djdefi">djdefi</a>
         &#8226; <a href="https://github.com/steve-chavez">steve-chavez</a>
       </div>
     </div>


### PR DESCRIPTION
Until now, the website header instructed the users about using `shellcheck` locally based on their distribution. However, Archlinux was missing even though it is supported.

With this commit, `pacman` is added to the list of pacage managers that help install shellcheck locally.